### PR TITLE
Fix regex parameters not being properly escaped

### DIFF
--- a/src/main/resources/default_config/default.txt
+++ b/src/main/resources/default_config/default.txt
@@ -412,7 +412,6 @@ ruleset {
     UnnecessarySemicolon
     UnnecessarySetter
     UnnecessaryStringInstantiation
-    UnnecessarySubstring
     UnnecessaryTernaryExpression
     UnnecessaryToString
     UnnecessaryTransientModifier

--- a/src/main/scala/codacy/codenarc/CodeNarc.scala
+++ b/src/main/scala/codacy/codenarc/CodeNarc.scala
@@ -35,7 +35,7 @@ object CodeNarc extends Tool {
 
   private def paramValueAsString(paramValue: JsValue): String =
     paramValue match {
-      case JsString(value) => s"'$value'"
+      case jsonEncodedString @ JsString(_) => s"'${jsonEncodedString.toString()}'"
       case v => v.toString
     }
 


### PR DESCRIPTION
With the change the following seems to work (as in doesn't blow up the tool) but still needs confirmation that the change is the proper fix and the parameter is properly applied to the rule.

Calling the tool with the following `.codacyrc` 
```
{
  "tools": [
    {
      "name": "codenarc",
      "patterns": [
        {
          "patternId": "DuplicateListLiteral",
          "parameters": [
            {
              "name": "doNotApplyToFilesMatching",
              "value": ".*(Spec)\\.groovy"
            }
          ]
        }
      ]
    }
  ],
  "files": null
}
```

```
❯ docker run --rm -v (pwd)/.codacyrc:/.codacyrc -v (pwd):/src -it codacy-codenarc:latest
```

before:
```
Error executing the tool
java.lang.IllegalStateException: An error occurred compiling the configuration file file:/tmp/codacycodenarc5658395085030988319.txt
startup failed:
Script1.groovy: 3: unexpected char: '\' @ line 3, column 38.
   doNotApplyToFilesMatching = '.*(Spec)\.groovy'
                                        ^

1 error

        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:80)
        at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:74)
        at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:84)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:59)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:237)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:249)
        at org.codenarc.ruleset.GroovyDslRuleSet$_evaluateDsl_closure2.doCall(GroovyDslRuleSet.groovy:69)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:263)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)
        at groovy.lang.Closure.call(Closure.java:405)
        at groovy.lang.Closure.call(Closure.java:421)
        at org.codehaus.groovy.runtime.IOGroovyMethods.withReader(IOGroovyMethods.java:1161)
        at org.codehaus.groovy.runtime.IOGroovyMethods.withReader(IOGroovyMethods.java:1210)
        at org.codehaus.groovy.runtime.dgm$924.invoke(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:244)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:53)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127)
        at org.codenarc.ruleset.GroovyDslRuleSet.evaluateDsl(GroovyDslRuleSet.groovy:64)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:43)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:190)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:58)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:51)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:156)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:168)
        at org.codenarc.ruleset.GroovyDslRuleSet.<init>(GroovyDslRuleSet.groovy:48)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:80)
        at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:105)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:59)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:237)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:249)
        at org.codenarc.ruleset.RuleSetUtil.loadRuleSetFile(RuleSetUtil.groovy:38)
        at org.codenarc.ruleset.RuleSetUtil$loadRuleSetFile.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127)
        at org.codenarc.CodeNarcRunner$_createInitialRuleSetFromFiles_closure6.doCall(CodeNarcRunner.groovy:184)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:263)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)
        at groovy.lang.Closure.call(Closure.java:405)
        at groovy.lang.Closure.call(Closure.java:421)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2330)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2315)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2356)
        at org.codehaus.groovy.runtime.dgm$186.invoke(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:244)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:53)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127)
        at org.codenarc.CodeNarcRunner.createInitialRuleSetFromFiles(CodeNarcRunner.groovy:183)
        at org.codenarc.CodeNarcRunner.createInitialRuleSet(CodeNarcRunner.groovy:172)
        at org.codenarc.CodeNarcRunner.buildRuleSet(CodeNarcRunner.groovy:135)
        at org.codenarc.CodeNarcRunner.execute(CodeNarcRunner.groovy:90)
        at codacy.codenarc.CodeNarc$.runAnalysis(CodeNarc.scala:149)
        at codacy.codenarc.CodeNarc$.run(CodeNarc.scala:135)
        at codacy.codenarc.CodeNarc$.$anonfun$apply$1(CodeNarc.scala:173)
        at scala.util.Try$.apply(Try.scala:210)
        at codacy.codenarc.CodeNarc$.apply(CodeNarc.scala:171)
        at com.codacy.tools.scala.seed.DockerEngine.executeTool(DockerEngine.scala:53)
        at com.codacy.tools.scala.seed.DockerEngine.$anonfun$main$2(DockerEngine.scala:35)
        at scala.util.Success.map(Try.scala:262)
        at com.codacy.tools.scala.seed.DockerEngine.$anonfun$main$1(DockerEngine.scala:27)
        at scala.util.Success.flatMap(Try.scala:258)
        at com.codacy.tools.scala.seed.DockerEngine.main(DockerEngine.scala:26)
        at codacy.Engine.main(Engine.scala)

```

now:
```
<<nothing really happens, means works properly>>
```

should fix IO-484.